### PR TITLE
PerfEnforce option on Ansible

### DIFF
--- a/myria/cluster/playbooks/roles/myria/tasks/main.yml
+++ b/myria/cluster/playbooks/roles/myria/tasks/main.yml
@@ -6,6 +6,7 @@
   apt: name="{{item}}" update_cache=yes
   with_items:
     - git
+    - mono-complete
   tags:
     - provision
 

--- a/myria/cluster/scripts/cli.py
+++ b/myria/cluster/scripts/cli.py
@@ -1157,13 +1157,7 @@ def create_cluster(cluster_name, **kwargs):
         kwargs['workers_per_node'] = 1
         #TEMPORARY WHILE NOT ON MAIN BRANCH OR IMAGE
         kwargs['unprovisioned'] = True
-        if kwargs['role'] is None:
-            click.echo("Failed, need to specify a role with access to S3...")
-            terminate_cluster(cluster_name, kwargs['region'], profile=kwargs['profile'], vpc_id=vpc_id)
-
-    ec2_ini_tmpfile = NamedTemporaryFile(delete=False)
-    os.environ['EC2_INI_PATH'] = ec2_ini_tmpfile.name
-    vpc_id = kwargs.get('vpc_id')
+        
     verbosity = 3 if kwargs['verbose'] else 0 if kwargs['silent'] else 1
     try:
         # we need to validate first without the VPC since it hasn't been determined yet

--- a/myria/cluster/scripts/cli.py
+++ b/myria/cluster/scripts/cli.py
@@ -1143,8 +1143,6 @@ def run():
     type=click.Choice(LOG_LEVELS), default=DEFAULTS['cluster_log_level'])
 @click.option('--perfenforce', is_flag=True, help="Enable PerfEnforce (will override default cluster configuration)")
 def create_cluster(cluster_name, **kwargs):
-    click.echo(kwargs)
-
     # If perfenforce is enabled, override the cluster configuration
     if kwargs['perfenforce']:
         click.echo("Adjusting cluster options for PerfEnforce...")

--- a/myria/cluster/scripts/cli.py
+++ b/myria/cluster/scripts/cli.py
@@ -1148,14 +1148,13 @@ def create_cluster(cluster_name, **kwargs):
     # If perfenforce is enabled, override the cluster configuration
     if kwargs['perfenforce']:
         click.echo("Adjusting cluster options for PerfEnforce...")
-        kwargs['cluster_size'] = 12
+        kwargs['cluster_size'] = 13
         kwargs['instance_type'] = 'm4.xlarge'
         kwargs['worker_mem'] = 12
         kwargs['worker_vcores'] = 2
         kwargs['node_mem_gb'] = 13
         kwargs['node_vcores'] = 3
         kwargs['workers_per_node'] = 1
-        #TEMPORARY WHILE NOT ON MAIN BRANCH OR IMAGE
         kwargs['unprovisioned'] = True
         
     verbosity = 3 if kwargs['verbose'] else 0 if kwargs['silent'] else 1
@@ -1297,7 +1296,12 @@ http://{coordinator_public_hostname}:{ganglia_web_port}
 
 Jupyter notebook interface:
 http://{coordinator_public_hostname}:{jupyter_web_port}
-""").format(coordinator_public_hostname=coordinator_public_hostname, myria_web_port=ANSIBLE_GLOBAL_VARS['myria_web_port'],
+""" + (
+"""
+PerfEnforce web interface:
+http://{coordinator_public_hostname}:{myria_web_port}/perfenforce
+""" if (kwargs.get('perfenforce')) else "")
+).format(coordinator_public_hostname=coordinator_public_hostname, myria_web_port=ANSIBLE_GLOBAL_VARS['myria_web_port'],
            myria_rest_port=ANSIBLE_GLOBAL_VARS['myria_rest_port'], ganglia_web_port=ANSIBLE_GLOBAL_VARS['ganglia_web_port'],
            jupyter_web_port=ANSIBLE_GLOBAL_VARS['jupyter_web_port'], private_key_file=kwargs['private_key_file'],
            remote_user=ANSIBLE_GLOBAL_VARS['remote_user'], script_name=SCRIPT_NAME, cluster_name=cluster_name,

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         # 2.2 introduced regression in git module:
         # https://github.com/ansible/ansible-modules-core/issues/5504
         'ansible == 2.1.2.0',
-        'click >= 6.6',
+        'click-uwescience >= 6.6',
         'boto >= 2.40.0',
         'PyYAML >= 3.11',
         'requests >= 2.10.0',


### PR DESCRIPTION
This PR focuses on adding a ```perfenforce``` optional flag to myria-cluster. When using this flag, it will create a custom cluster configuration. 

PerfEnforce also requires mono, since the source will be running an executable for PSLA generation. 

If the flag is used, it will also print the address for the PerfEnforce web interface.